### PR TITLE
Add authentication (login/logout) — fixes #18

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,10 +5,14 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 import os
+import json
+import hashlib
+import secrets
 from pathlib import Path
 
 app = FastAPI(title="Mergington High School API",
@@ -18,6 +22,24 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+# Load teacher credentials from teachers.json
+teachers_file = Path(__file__).parent / "teachers.json"
+with open(teachers_file) as f:
+    teachers_data = json.load(f)
+teachers = {t["username"]: t for t in teachers_data["teachers"]}
+
+# In-memory session store: token -> username
+active_sessions: dict[str, str] = {}
+
+security = HTTPBearer(auto_error=False)
+
+
+def get_current_teacher(credentials: HTTPAuthorizationCredentials = Depends(security)) -> str:
+    """Return username if the Bearer token is valid, else raise 401."""
+    if credentials is None or credentials.credentials not in active_sessions:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    return active_sessions[credentials.credentials]
 
 # In-memory activity database
 activities = {
@@ -83,13 +105,41 @@ def root():
     return RedirectResponse(url="/static/index.html")
 
 
+@app.post("/auth/login")
+def login(username: str, password: str):
+    """Authenticate a teacher and return a session token."""
+    teacher = teachers.get(username)
+    if not teacher:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    expected = hashlib.sha256((teacher["salt"] + password).encode()).hexdigest()
+    if not secrets.compare_digest(expected, teacher["password_hash"]):
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    token = secrets.token_hex(32)
+    active_sessions[token] = username
+    return {"token": token, "username": username}
+
+
+@app.post("/auth/logout")
+def logout(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    """Invalidate the current session token."""
+    if credentials and credentials.credentials in active_sessions:
+        del active_sessions[credentials.credentials]
+    return {"message": "Logged out successfully"}
+
+
+@app.get("/auth/me")
+def get_me(username: str = Depends(get_current_teacher)):
+    """Return the currently authenticated teacher's username."""
+    return {"username": username}
+
+
 @app.get("/activities")
 def get_activities():
     return activities
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, _: str = Depends(get_current_teacher)):
     """Sign up a student for an activity"""
     # Validate activity exists
     if activity_name not in activities:
@@ -111,7 +161,7 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str, _: str = Depends(get_current_teacher)):
     """Unregister a student from an activity"""
     # Validate activity exists
     if activity_name not in activities:

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -2,7 +2,85 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitiesList = document.getElementById("activities-list");
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
+  const signupContainer = document.getElementById("signup-container");
   const messageDiv = document.getElementById("message");
+
+  // Auth elements
+  const loginFormInline = document.getElementById("login-form-inline");
+  const loggedInBar = document.getElementById("logged-in-bar");
+  const loggedInUser = document.getElementById("logged-in-user");
+  const loginBtn = document.getElementById("login-btn");
+  const logoutBtn = document.getElementById("logout-btn");
+  const loginError = document.getElementById("login-error");
+
+  // Session state
+  let authToken = sessionStorage.getItem("authToken") || null;
+  let currentUser = sessionStorage.getItem("currentUser") || null;
+
+  function updateAuthUI() {
+    if (authToken) {
+      loginFormInline.classList.add("hidden");
+      loggedInBar.classList.remove("hidden");
+      loggedInUser.textContent = `👤 ${currentUser}`;
+      signupContainer.classList.remove("hidden");
+    } else {
+      loginFormInline.classList.remove("hidden");
+      loggedInBar.classList.add("hidden");
+      signupContainer.classList.add("hidden");
+    }
+    // Re-render activities to update delete buttons
+    fetchActivities();
+  }
+
+  // Login
+  loginBtn.addEventListener("click", async () => {
+    const username = document.getElementById("username-input").value.trim();
+    const password = document.getElementById("password-input").value;
+    loginError.classList.add("hidden");
+    try {
+      const response = await fetch(
+        `/auth/login?username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`,
+        { method: "POST" }
+      );
+      if (response.ok) {
+        const data = await response.json();
+        authToken = data.token;
+        currentUser = data.username;
+        sessionStorage.setItem("authToken", authToken);
+        sessionStorage.setItem("currentUser", currentUser);
+        document.getElementById("username-input").value = "";
+        document.getElementById("password-input").value = "";
+        updateAuthUI();
+      } else {
+        const err = await response.json();
+        loginError.textContent = err.detail || "Login failed";
+        loginError.classList.remove("hidden");
+      }
+    } catch {
+      loginError.textContent = "Login request failed";
+      loginError.classList.remove("hidden");
+    }
+  });
+
+  // Allow pressing Enter in password field to trigger login
+  document.getElementById("password-input").addEventListener("keydown", (e) => {
+    if (e.key === "Enter") loginBtn.click();
+  });
+
+  // Logout
+  logoutBtn.addEventListener("click", async () => {
+    if (authToken) {
+      await fetch("/auth/logout", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${authToken}` },
+      }).catch(() => {});
+    }
+    authToken = null;
+    currentUser = null;
+    sessionStorage.removeItem("authToken");
+    sessionStorage.removeItem("currentUser");
+    updateAuthUI();
+  });
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -30,7 +108,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${authToken ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>` : ""}</li>`
                   )
                   .join("")}
               </ul>
@@ -80,6 +158,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: authToken ? { Authorization: `Bearer ${authToken}` } : {},
         }
       );
 
@@ -124,6 +203,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: authToken ? { Authorization: `Bearer ${authToken}` } : {},
         }
       );
 
@@ -156,5 +236,5 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   // Initialize app
-  fetchActivities();
+  updateAuthUI();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,6 +10,18 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="auth-bar">
+        <div id="login-form-inline">
+          <input type="text" id="username-input" placeholder="Teacher username" />
+          <input type="password" id="password-input" placeholder="Password" />
+          <button id="login-btn">Login</button>
+          <span id="login-error" class="hidden error-msg"></span>
+        </div>
+        <div id="logged-in-bar" class="hidden">
+          <span id="logged-in-user"></span>
+          <button id="logout-btn">Logout</button>
+        </div>
+      </div>
     </header>
 
     <main>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -28,6 +28,44 @@ header h1 {
   margin-bottom: 10px;
 }
 
+#auth-bar {
+  margin-top: 12px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+#login-form-inline input {
+  padding: 5px 8px;
+  border-radius: 4px;
+  border: none;
+  margin-right: 4px;
+}
+
+#login-form-inline button, #logout-btn {
+  padding: 5px 12px;
+  border-radius: 4px;
+  border: none;
+  background-color: #fff;
+  color: #1a237e;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+#logged-in-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: #fff;
+}
+
+.error-msg {
+  color: #ffcccc;
+  font-size: 0.85em;
+}
+
 main {
   display: flex;
   flex-wrap: wrap;

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,9 @@
+{
+  "teachers": [
+    {
+      "username": "msteacher",
+      "password_hash": "17ec1430c22900265cd3294673ce1646365f9de76e9f44788c38c08ae4faaa3d",
+      "salt": "c4808a901c391d7f9272319bd944d6d7"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #18

Implements login/logout flow with teacher authentication and protects signup/unregister endpoints.

## Changes

### Backend (`src/app.py`)
- Load teacher credentials from `src/teachers.json` (salted SHA-256 hashes)
- In-memory session store (Bearer token → username)
- `POST /auth/login` — validates credentials, returns session token
- `POST /auth/logout` — invalidates token
- `GET /auth/me` — returns current authenticated user
- `/signup` and `/unregister` endpoints now require a valid Bearer token (return 401 otherwise)

### New file (`src/teachers.json`)
- Stores teacher usernames and salted password hashes (no plain-text passwords)

### Frontend (`src/static/index.html`, `app.js`, `styles.css`)
- Login panel in the header (username + password fields + Login button)
- Shows authenticated teacher name and Logout button when logged in
- Sign-up form hidden for unauthenticated users (students can still view activities)
- ❌ unregister buttons only visible when logged in as a teacher
- Token stored in `sessionStorage` and sent as `Authorization: Bearer` header